### PR TITLE
Add a shared lib build.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -50,7 +50,7 @@ with open('testing-flags/test.c', 'w') as f:
 cc = 'gcc'
 
 cflags = '$CFLAGS'
-for flag in ['-O2', '-Wall', '-Werror', '-std=c99', '-g', '-mtune=native']:
+for flag in ['-O2', '-Wall', '-Werror', '-std=c99', '-g', '-mtune=native', '-fpic']:
     if not os.system('cd testing-flags && %s %s %s -c test.c' %
                      (cc, cflags, flag)):
         cflags += ' ' + flag
@@ -78,6 +78,13 @@ print("""
 < libbigbro.a
 > bigbro
 """ % (cc, cflags))
+
+print("""
+| %s %s -shared -o libbigbro.so bigbro-%s.o
+< bigbro-%s.o
+> libbigbro.so
+""" % (cc, cflags, platform, platform))
+
 
 winlibraryfiles = ['bigbro-windows.c', 'win32/inject.c',
                    'win32/queue.c', 'win32/create_dlls.c', 'win32/dll_paths.c']


### PR DESCRIPTION
This is a proposal to try to build bigbro with a shared library target.  My motivation is playing around with something fac-like.  With bigbro as a shared library, this makes experimenting in python (and probably other languages) pretty simple:

```python
# Invoking the bigbro library
from cffi import FFI
ffi = FFI()
lib = ffi.dlopen("./libbigbro.so")

ffi.cdef("""
typedef int pid_t;
int bigbro(const char *workingdir, pid_t *child_ptr,
           int stdoutfd, int stderrfd,
           char *envp[], // Must be 0 as invoked below
           const char *commandline, char ***read_from_directories,
           char ***read_from_files, char ***written_to_files);
""", override=True)

def read_returned_array(val):
    arr = list()
    count = 0
    try:
        while True:
            arr.append(ffi.string(val[0][count]))
            count += 1
    except RuntimeError as re:
        return arr

def call_bigbro_lib(workingdir, cmdline):
    cwd = ffi.new("char[]", workingdir)
    pid = ffi.new("int *")
    command = ffi.new("char[]", cmdline)
    read_from_dirs = ffi.new("char ***")
    read_from_files = ffi.new("char ***")
    written_to_files = ffi.new("char ***")

    lib.bigbro(cwd, pid, 1, 2,
               ffi.NULL,
               command,
               read_from_dirs, read_from_files, written_to_files)
    return {
        "read_from_files": read_returned_array(read_from_files),
        "read_from_dirs": read_returned_array(read_from_dirs),
        "written_to_files": read_returned_array(written_to_files),
        "pid": pid
    }
```
This works fine on linux, I'm not sure  if this works for windows.

