### PR TITLE
Unused result from write() fails compilation on Ubuntu 16.04 container

### DIFF
--- a/bigbro-linux.c
+++ b/bigbro-linux.c
@@ -603,7 +603,7 @@ void bigbro_before_exec(void) {
     // using ptrace.  Perhaps we should return with an error?
     static const char *seccomp_warning =
       "Unable to trace child process, perhaps seccomp too strict?!\n";
-    write(2, seccomp_warning, strlen(seccomp_warning));
+    (void) write(2, seccomp_warning, strlen(seccomp_warning));
   } else {
     kill(getpid(), SIGSTOP);
   }

--- a/bigbro-linux.c
+++ b/bigbro-linux.c
@@ -603,7 +603,7 @@ void bigbro_before_exec(void) {
     // using ptrace.  Perhaps we should return with an error?
     static const char *seccomp_warning =
       "Unable to trace child process, perhaps seccomp too strict?!\n";
-    (void) write(2, seccomp_warning, strlen(seccomp_warning));
+    (void)(write(2, seccomp_warning, strlen(seccomp_warning))+1);
   } else {
     kill(getpid(), SIGSTOP);
   }


### PR DESCRIPTION
I was trying to build this using the `ubuntu:16.04` container and ran into this error.
There probably is a better way to to this.